### PR TITLE
Fix case for Arduino.h include

### DIFF
--- a/src/BluetoothA2DPSource.h
+++ b/src/BluetoothA2DPSource.h
@@ -19,7 +19,7 @@
 #ifndef __A2DP_SOURCE_H__
 #define __A2DP_SOURCE_H__
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/timers.h"
 #include "freertos/xtensa_api.h"

--- a/src/SoundData.h
+++ b/src/SoundData.h
@@ -1,7 +1,7 @@
 #ifndef __SOUND_DATA_H__
 #define __SOUND_DATA_H__
 
-#include "arduino.h"
+#include "Arduino.h"
 
 /**
  * Sound data as byte stream. We support TwoChannelSoundData (uint16_t + uint16_t) and 


### PR DESCRIPTION
Needed if building on a Linux workstation where the correct case is required.