### PR TITLE
Add packet access for receiver and document packet received callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,33 @@ void loop() {
 
 The output goes now to the DAC pins G26/G27.
 
+## Accessing the sink data stream with callbacks
+You can be notified when a packet is received:
+
+```
+// In the setup function:
+a2dp_sink.set_on_data_received(data_received_callback);
+
+
+// Then somewhere in your sketch:
+void data_received_callback() {
+  Serial.println("Data packet received");
+}
+```
+
+Or you can access the packet:
+
+```
+// In the setup function:
+a2dp_sink.set_stream_reader(read_data_stream);
+
+// Then somewhere in your sketch:
+void read_data_stream(const uint8_t *data, uint32_t length)
+{
+  // Do something with the data packet
+}
+```
+
 
 ## Sending Data from a A2DS Data Source with a Callback
 

--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -103,6 +103,10 @@ void BluetoothA2DPSink::set_i2s_config(i2s_config_t i2s_config){
   this->i2s_config = i2s_config;
 }
 
+void BluetoothA2DPSink::set_stream_reader(void (*callBack)(const uint8_t*, uint32_t)){
+  this->stream_reader = callBack;
+}
+
 void BluetoothA2DPSink::set_on_data_received(void (*callBack)()){
   this->data_received = callBack;
 }
@@ -519,7 +523,11 @@ void  BluetoothA2DPSink::audio_data_callback(const uint8_t *data, uint32_t len) 
 
    if (i2s_bytes_written<len){
       ESP_LOGE(BT_AV_TAG, "Timeout: not all bytes were written to I2S");
-   } 
+   }
+   
+   if (stream_reader!=NULL){
+   	  stream_reader(data, len);
+   }
    
    if (data_received!=NULL){
    	  data_received();

--- a/src/BluetoothA2DPSink.h
+++ b/src/BluetoothA2DPSink.h
@@ -83,6 +83,7 @@ class BluetoothA2DPSink {
     void start(char* name);
     esp_a2d_audio_state_t get_audio_state();
     esp_a2d_mct_t get_audio_type();
+    void set_stream_reader(void (*callBack)(const uint8_t*, uint32_t));
     void set_on_data_received(void (*callBack)());
 
     /**
@@ -114,6 +115,7 @@ class BluetoothA2DPSink {
     esp_a2d_audio_state_t audio_state;
     esp_a2d_mct_t audio_type;
     void (*data_received)() = NULL;
+    void (*stream_reader)(const uint8_t*, uint32_t) = NULL;
 
     // priate methods
     int init_bluetooth();


### PR DESCRIPTION
Thank you for setting this up and sharing it!

I needed to access the incoming packets for analysis, so I added a new callback.

I also didn't see the data_received callback on the readme, so I added notes for both.