### PR TITLE
Expanding 16-bit PCM to 32-bit PCM

### DIFF
--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -698,7 +698,7 @@ void BluetoothA2DPSink::audio_data_callback(const uint8_t *data, uint32_t len) {
         }
 
         size_t i2s_bytes_written;
-        if (i2s_write(i2s_port,(void*) data, len, &i2s_bytes_written, portMAX_DELAY)!=ESP_OK){
+        if (i2s_write_expand(i2s_port,(void*) data, len, I2S_BITS_PER_SAMPLE_16BIT, i2s_config.bits_per_sample, &i2s_bytes_written, portMAX_DELAY) != ESP_OK){
             ESP_LOGE(BT_AV_TAG, "i2s_write has failed");    
         }
 

--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -503,16 +503,15 @@ uint16_t BluetoothA2DPSink::sample_rate(){
     return i2s_config.sample_rate;
 }
 
-void BluetoothA2DPSink::expand_audio_bits_per_sample(size_t aim_bits, size_t src_bits)
-{
+void BluetoothA2DPSink::expand_audio_bits_per_sample(i2s_bits_per_sample_t aim_bits, i2s_bits_per_sample_t src_bits) {
     ESP_LOGD(BT_AV_TAG, "%s", __func__);
 
     if(is_i2s_output){
         if((src_bits > aim_bits) || (src_bits < I2S_BITS_PER_SAMPLE_16BIT)){
-            ESP_LOGE("param error. src_bits:%d aim_bits:%d", src_bits, aim_bits);
+            ESP_LOGE(BT_AV_TAG, "param error. src_bits:%d aim_bits:%d", src_bits, aim_bits);
             return;
-        } 
-    
+        }
+
         i2s_config.bits_per_sample = aim_bits;
         m_src_bits                 = src_bits;
     }

--- a/src/BluetoothA2DPSink.h
+++ b/src/BluetoothA2DPSink.h
@@ -179,7 +179,7 @@ class BluetoothA2DPSink {
     esp_bd_addr_t last_connection = {0};
     bool is_i2s_output = true;
     bool mono_downmix = false;
-    size_t m_src_bits;
+    i2s_bits_per_sample_t m_src_bits;
 #ifdef CURRENT_ESP_IDF
     esp_bt_discovery_mode_t discoverability = ESP_BT_GENERAL_DISCOVERABLE;
 #endif

--- a/src/BluetoothA2DPSink.h
+++ b/src/BluetoothA2DPSink.h
@@ -147,7 +147,7 @@ class BluetoothA2DPSink {
     /// @param src_bits Source audio bit (I2S_BITS_PER_SAMPLE_16BIT)
     ///
     /// @param aim_bits Bit wanted, no more than 32, and must be greater than src_bits
-    void expand_audio_bits_per_sample(size_t aim_bits, size_t src_bits = I2S_BITS_PER_SAMPLE_16BIT);
+    void expand_audio_bits_per_sample(i2s_bits_per_sample_t aim_bits, i2s_bits_per_sample_t src_bits = I2S_BITS_PER_SAMPLE_16BIT);
 
 #ifdef CURRENT_ESP_IDF
     // Bluetooth discoverability

--- a/src/BluetoothA2DPSink.h
+++ b/src/BluetoothA2DPSink.h
@@ -142,6 +142,13 @@ class BluetoothA2DPSink {
 
     uint16_t sample_rate();
 
+    /// @brief Expanding the number of bits per sample. 
+    ///        For example, expanding 16-bit PCM to 32-bit PCM.
+    /// @param src_bits Source audio bit (I2S_BITS_PER_SAMPLE_16BIT)
+    ///
+    /// @param aim_bits Bit wanted, no more than 32, and must be greater than src_bits
+    void expand_audio_bits_per_sample(size_t aim_bits, size_t src_bits = I2S_BITS_PER_SAMPLE_16BIT);
+
 #ifdef CURRENT_ESP_IDF
     // Bluetooth discoverability
     virtual void set_discoverability(esp_bt_discovery_mode_t d);
@@ -172,6 +179,7 @@ class BluetoothA2DPSink {
     esp_bd_addr_t last_connection = {0};
     bool is_i2s_output = true;
     bool mono_downmix = false;
+    size_t m_src_bits;
 #ifdef CURRENT_ESP_IDF
     esp_bt_discovery_mode_t discoverability = ESP_BT_GENERAL_DISCOVERABLE;
 #endif


### PR DESCRIPTION
Hi. @pschatzmann 

I would like to send a pull request for this issue. Please review it. It would be nice to get some pointers.
I have done [a simple unit test](https://github.com/riraosan/ESP32_BT-A2DP_Receiver/blob/master/test/test_main.cpp) with PlatformIO.
As it turns out, only 32-bit samples work with my DAC.
I would like you to confirm if it works with [16-bit samples](https://github.com/riraosan/ESP32_BT-A2DP_Receiver/blob/5349f02ec88b2b5ea2b91bca3ba38da28cec3ba5/test/test_main.cpp#L47-L55) or not. 
Thanks!👍

(See Also)
https://github.com/pschatzmann/ESP32-A2DP/issues/54