### PR TITLE
Add method to disconnect current connection

### DIFF
--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -67,6 +67,23 @@ BluetoothA2DPSink::~BluetoothA2DPSink() {
     }
 }
 
+void BluetoothA2DPSink::disconnect()
+{
+    ESP_LOGI(BT_AV_TAG, "discconect a2d");
+    esp_err_t status = esp_a2d_sink_disconnect(last_connection);
+    if (status == ESP_FAIL)
+    {
+        ESP_LOGE(BT_AV_TAG, "Failed disconnecting to device!");
+    }
+    // clean_last_connection();
+
+    // ESP_LOGI(BT_AV_TAG, "deinit avrc");
+    // if (esp_avrc_ct_deinit() != ESP_OK)
+    // {
+    //     ESP_LOGE(BT_AV_TAG, "Failed to deinit avrc");
+    // }
+}
+
 void BluetoothA2DPSink::end(bool release_memory) {
     // reconnect does not work after end
     clean_last_connection();

--- a/src/BluetoothA2DPSink.h
+++ b/src/BluetoothA2DPSink.h
@@ -101,8 +101,11 @@ class BluetoothA2DPSink {
     /// starts the I2S bluetooth sink with the inidicated name
     virtual void start(const char* name, bool auto_reconect=true);
 
-    /// starts the I2S bluetooth sink with the inidicated name - if you release the memory a future start is not possible
+    /// ends the I2S bluetooth sink with the indicated name - if you release the memory a future start is not possible
     virtual void end(bool release_memory=false);
+    
+    /// Disconnects the remote a2d connection, allowing for a reconnection
+    virtual void disconnect();
 
     /// Determine the actual audio state
     virtual esp_a2d_audio_state_t get_audio_state();
@@ -141,7 +144,7 @@ class BluetoothA2DPSink {
     virtual void set_mono_downmix(bool enabled) { mono_downmix = enabled; }
     /// Defines the bits per sample for output (if > 16 output will be expanded)
     virtual void set_bits_per_sample(int bps) { i2s_config.bits_per_sample = (i2s_bits_per_sample_t) bps; }
-
+    
     /// Provides the actually set data rate (in samples per second)
     uint16_t sample_rate();
 


### PR DESCRIPTION
Add a wrapper to call [`esp_a2d_sink_disconnect`](https://docs.espressif.com/projects/esp-idf/en/v4.2-beta1/esp32/api-reference/bluetooth/esp_a2dp.html#_CPPv423esp_a2d_sink_disconnect13esp_bd_addr_t) allowing you to disconnect the currently connected device. 

I am not sure if the the commented section is required, it works in my simple case - but I must admit I don't have sufficient knowledge here..