### PR TITLE
Enable APLL as clock

### DIFF
--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -65,7 +65,7 @@ BluetoothA2DPSink::BluetoothA2DPSink() {
             .intr_alloc_flags = 0, // default interrupt priority
             .dma_buf_count = 8,
             .dma_buf_len = 64,
-            .use_apll = false,
+            .use_apll = true,
             .tx_desc_auto_clear = true // avoiding noise in case of data unavailability
         };
 


### PR DESCRIPTION
I had some issues where the Arduino was restarting after playing a stream for a longer period.  This seemed to be related to an inaccurate clock of my ESP32. With this change, I could fix that problem. I'm not sure if this flag causes issues if it is set by default?