### PR TITLE
Enable easy detection of failed authentication

### DIFF
--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -431,6 +431,10 @@ void BluetoothA2DPSink::app_gap_callback(esp_bt_gap_cb_event_t event, esp_bt_gap
 
             } else {
                 ESP_LOGE(BT_AV_TAG, "authentication failed, status:%d", param->auth_cmpl.stat);
+                // reset pin_code data to "undefined" after authentication failure
+                // just like when in disconnected state
+                pin_code_int = 0;
+                pin_code_request = Undefined;
             }
             break;
         }


### PR DESCRIPTION
After failed authentication attempt, code resets received pin_code and state
to 0 / Undefined. 

Without this change, after failed authenication
the BluetoothA2DPSink::pin_code()  still returns
the code and the application will not be able
to easily detect that no authentication is in
progress by checking pin_code() == 0.

Only other way to achieve this without code change 
would be to subclass BluetoothA2DPSink and provide
app_gap_callback but that seems to be not really appropriate.

BTW, thanks for the code, made making a bluetooth speaker a breeze.

If you are interested, I could provide an example for the examples folder which demonstrates how to use
this to build a simple bluetooth sink which accepts pairing request only after pressing a key.
EDIT: Of course, bt_music_receiver_simple_with_pin.ino will also demonstrate this as it will with this fix recover from a failed authentication (albeit without telling the user). 

 