### PR TITLE
Add missing SRC for idf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # -- copyright GPLv3
 
 idf_component_register(
-    SRCS "src/BluetoothA2DPCommon.cpp" "src/BluetoothA2DPSink.cpp" "src/BluetoothA2DPSource.cpp"
+    SRCS "src/BluetoothA2DPCommon.cpp" "src/BluetoothA2DPSink.cpp" "src/BluetoothA2DPSource.cpp" "src/SoundData.cpp"
     INCLUDE_DIRS "src"
     REQUIRES bt esp_common freertos hal log nvs_flash
 )


### PR DESCRIPTION
`src/SoundData.cpp` is currently missing from `idf_component_register(SRCS ...`. It isn't used in the IDF example which is why that works but throws an `undefined reference to SoundData::doLoop()` error during the `Linking CXX executable` step when running the `bt_music_sender` example. PR fixes this issue.