### PR TITLE
Fixed Bluetooth Source pairing so it works with more devices

### DIFF
--- a/src/BluetoothA2DPSource.cpp
+++ b/src/BluetoothA2DPSource.cpp
@@ -377,8 +377,8 @@ void BluetoothA2DPSource::filter_inquiry_scan_result(esp_bt_gap_cb_param_t *para
     int32_t rssi = -129; /* invalid value */
     uint8_t *eir = NULL;
     esp_bt_gap_dev_prop_t *p;
-
-    ESP_LOGI(BT_AV_TAG, "Scanned device: %s", to_str(param->disc_res.bda));
+	
+	ESP_LOGI(BT_AV_TAG, "Scanned device: %s", to_str(param->disc_res.bda));
     for (int i = 0; i < param->disc_res.num_prop; i++) {
         p = param->disc_res.prop + i;
         switch (p->type) {
@@ -398,22 +398,21 @@ void BluetoothA2DPSource::filter_inquiry_scan_result(esp_bt_gap_cb_param_t *para
             break;
         }
     }
-
-    /* search for device with MAJOR DEVICE class as "Phone" or "Audio/Visual" in COD */
-    if ((esp_bt_gap_get_cod_major_dev(cod) == ESP_BT_COD_MAJOR_DEV_PHONE) ||
-        (esp_bt_gap_get_cod_major_dev(cod) == ESP_BT_COD_MAJOR_DEV_AV))
+    /* search for device with MAJOR DEVICE class as "Audio/Visual" in COD */
+    if ((esp_bt_gap_get_cod_major_dev(cod) == ESP_BT_COD_MAJOR_DEV_AV))
 	{
 		/* search for device name in its extended inqury response */
 		if (eir)
 		{
+			ESP_LOGI(BT_AV_TAG, "--Compatiblity: Compatible");
 			get_name_from_eir(eir, s_peer_bdname, NULL);
-			ESP_LOGI(BT_AV_TAG, "Device discovery found: %s", s_peer_bdname);
+			ESP_LOGI(BT_AV_TAG, "--Name: %s", s_peer_bdname);
 
 			bool found = false;
 			for (const char* name : bt_names)
 			{
 				int len = strlen(name);
-				ESP_LOGI(BT_AV_TAG, "Checking name: %s", name);
+				ESP_LOGI(BT_AV_TAG, "--Checking match: %s", name);
 				if (strncmp((char *)s_peer_bdname, name, len) == 0) {
 					this->bt_name = (char *) s_peer_bdname;
 					found = true;
@@ -422,19 +421,28 @@ void BluetoothA2DPSource::filter_inquiry_scan_result(esp_bt_gap_cb_param_t *para
 			}
 			if (found)
 			{
-				ESP_LOGI(BT_AV_TAG, "Found a target device, address %s, name %s", to_str(param->disc_res.bda), s_peer_bdname);
+				ESP_LOGI(BT_AV_TAG, "--Result: Target device found");
 				s_a2d_state = APP_AV_STATE_DISCOVERED;
 				memcpy(s_peer_bda, param->disc_res.bda, ESP_BD_ADDR_LEN);
 				set_last_connection(s_peer_bda);
 				ESP_LOGI(BT_AV_TAG, "Cancel device discovery ...");
 				esp_bt_gap_cancel_discovery();
 			}
+			else
+			{
+				ESP_LOGI(BT_AV_TAG, "--Result: Target device not found");
+			}
+		}
+		else
+		{
+			ESP_LOGI(BT_AV_TAG, "--Compatiblity: Scanned Device not Compatible");
 		}
 	}
 	else{
-		ESP_LOGI(BT_AV_TAG, "Scanned Device ""Major Device Type"" not Compatible. Expected Values: %x, %x\tActual Value%x", ESP_BT_COD_MAJOR_DEV_PHONE, ESP_BT_COD_MAJOR_DEV_AV, esp_bt_gap_get_cod_major_dev(cod));
-		return;
+		ESP_LOGI(BT_AV_TAG, "--Compatiblity: Scanned Device not Compatible.");
 	}
+	
+	
 }
 
 

--- a/src/BluetoothA2DPSource.cpp
+++ b/src/BluetoothA2DPSource.cpp
@@ -399,36 +399,42 @@ void BluetoothA2DPSource::filter_inquiry_scan_result(esp_bt_gap_cb_param_t *para
         }
     }
 
-    /* search for device with MAJOR service class as "rendering" in COD */
-    if (!esp_bt_gap_is_valid_cod(cod) ||
-            !(esp_bt_gap_get_cod_srvc(cod) & ESP_BT_COD_SRVC_RENDERING)) {
-        return;
-    }
+    /* search for device with MAJOR DEVICE class as "Phone" or "Audio/Visual" in COD */
+    if ((esp_bt_gap_get_cod_major_dev(cod) == ESP_BT_COD_MAJOR_DEV_PHONE) ||
+        (esp_bt_gap_get_cod_major_dev(cod) == ESP_BT_COD_MAJOR_DEV_AV))
+	{
+		/* search for device name in its extended inqury response */
+		if (eir)
+		{
+			get_name_from_eir(eir, s_peer_bdname, NULL);
+			ESP_LOGI(BT_AV_TAG, "Device discovery found: %s", s_peer_bdname);
 
-    /* search for device name in its extended inqury response */
-    if (eir) {
-        get_name_from_eir(eir, s_peer_bdname, NULL);
-        ESP_LOGI(BT_AV_TAG, "Device discovery found: %s", s_peer_bdname);
-
-        bool found = false;
-        for (const char* name : bt_names){
-            int len = strlen(name);
-            ESP_LOGI(BT_AV_TAG, "Checking name: %s", name);
-            if (strncmp((char *)s_peer_bdname, name, len) == 0) {
-                this->bt_name = (char *) s_peer_bdname;
-                found = true;
-                break;
-            }
-        }
-        if (found){
-            ESP_LOGI(BT_AV_TAG, "Found a target device, address %s, name %s", to_str(param->disc_res.bda), s_peer_bdname);
-            s_a2d_state = APP_AV_STATE_DISCOVERED;
-            memcpy(s_peer_bda, param->disc_res.bda, ESP_BD_ADDR_LEN);
-            set_last_connection(s_peer_bda);
-            ESP_LOGI(BT_AV_TAG, "Cancel device discovery ...");
-            esp_bt_gap_cancel_discovery();
-        }
-    }
+			bool found = false;
+			for (const char* name : bt_names)
+			{
+				int len = strlen(name);
+				ESP_LOGI(BT_AV_TAG, "Checking name: %s", name);
+				if (strncmp((char *)s_peer_bdname, name, len) == 0) {
+					this->bt_name = (char *) s_peer_bdname;
+					found = true;
+					break;
+				}
+			}
+			if (found)
+			{
+				ESP_LOGI(BT_AV_TAG, "Found a target device, address %s, name %s", to_str(param->disc_res.bda), s_peer_bdname);
+				s_a2d_state = APP_AV_STATE_DISCOVERED;
+				memcpy(s_peer_bda, param->disc_res.bda, ESP_BD_ADDR_LEN);
+				set_last_connection(s_peer_bda);
+				ESP_LOGI(BT_AV_TAG, "Cancel device discovery ...");
+				esp_bt_gap_cancel_discovery();
+			}
+		}
+	}
+	else{
+		ESP_LOGI(BT_AV_TAG, "Scanned Device ""Major Device Type"" not Compatible. Expected Values: %x, %x\tActual Value%x", ESP_BT_COD_MAJOR_DEV_PHONE, ESP_BT_COD_MAJOR_DEV_AV, esp_bt_gap_get_cod_major_dev(cod));
+		return;
+	}
 }
 
 


### PR DESCRIPTION
These lines made it so this code would not pair with a lot of Bluetooth speakers:

/* search for device with MAJOR service class as "rendering" in COD */
    if (!esp_bt_gap_is_valid_cod(cod) ||
            !(esp_bt_gap_get_cod_srvc(cod) & ESP_BT_COD_SRVC_RENDERING)) {
        return;
    }

I modified the code so that it only validates against MAJOR DEVICE being AV. I also removed the esp_bt_gap_is_valid_cod check because I found that some of my bluetooth speakers did not pass that check, but they still were detected as valid AV devices. The rest of the changes are just clean up and a slight restructure of the filter_inquiry_scan_result function and ESP_LOG calls

/* search for device with MAJOR DEVICE class as "Audio/Visual" in COD */
    if ((esp_bt_gap_get_cod_major_dev(cod) == ESP_BT_COD_MAJOR_DEV_AV))
	{