### PR TITLE
Fix esp-idf version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,4 @@ idf_component_register(
     REQUIRES bt esp_common freertos hal log nvs_flash
 )
 
-target_compile_options(${COMPONENT_LIB} PUBLIC "-Wno-unused-variable" "-Wno-missing-field-initializers" "-fpermissive" "-DCURRENT_ESP_IDF" )
+target_compile_options(${COMPONENT_LIB} PUBLIC "-Wno-unused-variable" "-Wno-missing-field-initializers" "-fpermissive")

--- a/src/config.h
+++ b/src/config.h
@@ -2,19 +2,27 @@
 
 #define DEPRECATED __attribute__((deprecated))
 
-
+// Enable ESP_IDF_4 if we are using a current version of ESP IDF e.g. 4.3
+// ESP Arduino 2.0 is using ESP IDF 4.4
 #if __has_include("esp_arduino_version.h")
 #include "esp_arduino_version.h"
+#  if ESP_ARDUINO_VERSION_MAJOR >= 2
+#    define ESP_IDF_4
+#  endif
+#endif
+
+#if __has_include("esp_idf_version.h")
+#include "esp_idf_version.h"
+#  if ESP_IDF_VERSION_MAJOR >= 4
+#    ifndef ESP_IDF_4
+#      define ESP_IDF_4
+#    endif
+#  endif
 #endif
 
 #ifndef AUTOCONNECT_TRY_NUM
 #define AUTOCONNECT_TRY_NUM 1000
-#endif
 
-// Enable ESP_IDF_4 if we are using a current version of ESP IDF e.g. 4.3
-// ESP Arduino 2.0 is using ESP IDF 4.4
-#if ESP_IDF_VERSION_MAJOR >= 4 || ESP_ARDUINO_VERSION_MAJOR >= 2
-#define ESP_IDF_4
 #endif
 
 // Compile ESP32C3


### PR DESCRIPTION
The version check doesn't work unless it's performed after declaration of the esp-idf header.