### PR TITLE
Cache volume factor

### DIFF
--- a/src/A2DPVolumeControl.h
+++ b/src/A2DPVolumeControl.h
@@ -27,6 +27,8 @@
 class A2DPVolumeControl {
 
     protected:
+        bool is_volume_used = false;
+        bool mono_downmix = false;
         int32_t volumeFactor;
         int32_t volumeFactorMax;
 
@@ -35,7 +37,7 @@ class A2DPVolumeControl {
             volumeFactorMax = 0x1000;
         }
 
-        virtual void update_audio_data(Frame* data, uint16_t frameCount, bool mono_downmix, bool is_volume_used) {
+        virtual void update_audio_data(Frame* data, uint16_t frameCount) {
             if (data!=nullptr && frameCount>0 && ( mono_downmix || is_volume_used)) {
                 ESP_LOGD("VolumeControl", "update_audio_data");
                 for (int i=0;i<frameCount;i++){
@@ -64,6 +66,14 @@ class A2DPVolumeControl {
         // provides the max factor value 4096
         int32_t get_volume_factor_max() {
             return volumeFactorMax;
+        }
+
+        void set_enabled(bool enabled) {
+            is_volume_used = enabled;
+        }
+
+        void set_mono_downmix(bool enabled) {
+            mono_downmix = enabled;
         }
 
         virtual void set_volume(uint8_t volume) = 0;
@@ -127,6 +137,6 @@ class A2DPLinearVolumeControl : public A2DPVolumeControl {
  */
 class A2DPNoVolumeControl : public A2DPVolumeControl {
     public:
-        virtual void update_audio_data(Frame* data, uint16_t frameCount, bool mono_downmix, bool ivolume_used) {
+        virtual void update_audio_data(Frame* data, uint16_t frameCount) {
         }
 };

--- a/src/A2DPVolumeControl.h
+++ b/src/A2DPVolumeControl.h
@@ -25,12 +25,19 @@
  */
 
 class A2DPVolumeControl {
+
+    protected:
+        int32_t volumeFactor;
+        int32_t volumeFactorMax;
+
     public:
-        virtual void update_audio_data(Frame* data, uint16_t frameCount, uint8_t volume, bool mono_downmix, bool is_volume_used) {
+        A2DPVolumeControl() {
+            volumeFactorMax = 0x1000;
+        }
+
+        virtual void update_audio_data(Frame* data, uint16_t frameCount, bool mono_downmix, bool is_volume_used) {
             if (data!=nullptr && frameCount>0 && ( mono_downmix || is_volume_used)) {
                 ESP_LOGD("VolumeControl", "update_audio_data");
-                int32_t volumeFactor = get_volume_factor(volume);
-                int32_t max = get_volume_factor_max();
                 for (int i=0;i<frameCount;i++){
                     int32_t pcmLeft = data[i].channel1;
                     int32_t pcmRight = data[i].channel2;
@@ -40,8 +47,8 @@ class A2DPVolumeControl {
                     }
                     // adjust the volume
                     if (is_volume_used) {
-                        pcmLeft = pcmLeft * volumeFactor / max; 
-                        pcmRight = pcmRight * volumeFactor / max; 
+                        pcmLeft = pcmLeft * volumeFactor / volumeFactorMax;
+                        pcmRight = pcmRight * volumeFactor / volumeFactorMax;
                     }
                     data[i].channel1 = pcmLeft;
                     data[i].channel2 = pcmRight;
@@ -50,12 +57,16 @@ class A2DPVolumeControl {
         }
 
         // provides a factor in the range of 0 to 4096
-        virtual int32_t get_volume_factor(uint8_t volume) = 0;
+        int32_t get_volume_factor() {
+            return volumeFactor;
+        }
 
         // provides the max factor value 4096
-        virtual int32_t get_volume_factor_max() {
-            return 0x1000;
+        int32_t get_volume_factor_max() {
+            return volumeFactorMax;
         }
+
+        virtual void set_volume(uint8_t volume) = 0;
 };
 
 /**
@@ -64,20 +75,18 @@ class A2DPVolumeControl {
  * @copyright Apache License Version 2
  */
 class A2DPDefaultVolumeControl : public A2DPVolumeControl {
-        // provides a factor in the range of 0 to 4096
-        virtual int32_t get_volume_factor(uint8_t volume) {
+
+        virtual void set_volume(uint8_t volume) {
             constexpr double base = 1.4;
             constexpr double bits = 12;
             constexpr double zero_ofs = pow(base, -bits);
             constexpr double scale = pow(2.0, bits);
             double volumeFactorFloat = (pow(base, volume * bits / 127.0 - bits) - zero_ofs) * scale / (1.0 - zero_ofs);
-            int32_t volumeFactor = volumeFactorFloat;
+            volumeFactor = volumeFactorFloat;
             if (volumeFactor > 0x1000) {
                 volumeFactor = 0x1000;
             }
-            return volumeFactor;
         }
-
 };
 
 /**
@@ -85,17 +94,14 @@ class A2DPDefaultVolumeControl : public A2DPVolumeControl {
  * @author rbruelma
  */
 class A2DPSimpleExponentialVolumeControl : public A2DPVolumeControl {
-        // provides a factor in the range of 0 to 4096
-        virtual int32_t get_volume_factor(uint8_t volume) {
+        virtual void set_volume(uint8_t volume) {
             double volumeFactorFloat = volume;
             volumeFactorFloat = pow(2.0, volumeFactorFloat * 12.0 / 127.0);
             int32_t volumeFactor = volumeFactorFloat - 1.0;
             if (volumeFactor > 0xfff) {
                 volumeFactor = 0xfff;
             }
-            return volumeFactor;
         }
-
 };
 
 /**
@@ -104,12 +110,13 @@ class A2DPSimpleExponentialVolumeControl : public A2DPVolumeControl {
  * @copyright Apache License Version 2
  */
 class A2DPLinearVolumeControl : public A2DPVolumeControl {
-        // provides a factor in the range of 0 to 4096
-        virtual int32_t get_volume_factor(uint8_t volume) {
-            return volume;
+
+        A2DPLinearVolumeControl() {
+            volumeFactorMax = 128;
         }
-        virtual int32_t get_volume_factor_max() {
-            return 128;
+
+        virtual void set_volume(uint8_t volume) {
+            volumeFactor = volume;
         }
 };
 
@@ -120,6 +127,6 @@ class A2DPLinearVolumeControl : public A2DPVolumeControl {
  */
 class A2DPNoVolumeControl : public A2DPVolumeControl {
     public:
-        virtual void update_audio_data(Frame* data, uint16_t frameCount, uint8_t volume, bool mono_downmix, bool ivolume_used) {
+        virtual void update_audio_data(Frame* data, uint16_t frameCount, bool mono_downmix, bool ivolume_used) {
         }
 };

--- a/src/BluetoothA2DPCommon.h
+++ b/src/BluetoothA2DPCommon.h
@@ -119,6 +119,7 @@ class BluetoothA2DPCommon {
         virtual void set_volume(uint8_t volume){
             ESP_LOGI(BT_AV_TAG, "set_volume: %d", volume);
             volume_value = volume;
+            volume_control()->set_volume(volume);
             is_volume_used = true;
         }
             

--- a/src/BluetoothA2DPCommon.h
+++ b/src/BluetoothA2DPCommon.h
@@ -120,6 +120,7 @@ class BluetoothA2DPCommon {
             ESP_LOGI(BT_AV_TAG, "set_volume: %d", volume);
             volume_value = volume;
             volume_control()->set_volume(volume);
+            volume_control()->set_enabled(true);
             is_volume_used = true;
         }
             

--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -932,7 +932,7 @@ void BluetoothA2DPSink::audio_data_callback(const uint8_t *data, uint32_t len) {
     ESP_LOGD(BT_AV_TAG, "%s", __func__);
 
     // adjust the volume
-    volume_control()->update_audio_data((Frame*)data, len/4, s_volume, mono_downmix, is_volume_used);
+    volume_control()->update_audio_data((Frame*)data, len/4, mono_downmix, is_volume_used);
 
     // make data available via callback
     if (stream_reader!=nullptr){
@@ -1058,6 +1058,7 @@ void BluetoothA2DPSink::set_volume(uint8_t volume)
       volume = 0x7f;
   } 
   s_volume = volume & 0x7f;
+  volume_control()->set_volume(s_volume);
 
 #ifdef ESP_IDF_4
   volume_set_by_local_host(s_volume);
@@ -1195,6 +1196,8 @@ void BluetoothA2DPSink::volume_set_by_controller(uint8_t volume)
     _lock_release(&s_volume_lock);
     is_volume_used = true;
     
+    volume_control()->set_volume(s_volume);
+
     if (bt_volumechange!=nullptr){
         (*bt_volumechange)(s_volume);
     }    

--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -932,7 +932,7 @@ void BluetoothA2DPSink::audio_data_callback(const uint8_t *data, uint32_t len) {
     ESP_LOGD(BT_AV_TAG, "%s", __func__);
 
     // adjust the volume
-    volume_control()->update_audio_data((Frame*)data, len/4, mono_downmix, is_volume_used);
+    volume_control()->update_audio_data((Frame*)data, len/4);
 
     // make data available via callback
     if (stream_reader!=nullptr){
@@ -1053,12 +1053,12 @@ void BluetoothA2DPSink::rewind(){
 void BluetoothA2DPSink::set_volume(uint8_t volume)
 {
   ESP_LOGI(BT_AV_TAG, "set_volume %d", volume);
-  is_volume_used = true;
   if (volume > 0x7f) {
       volume = 0x7f;
   } 
   s_volume = volume & 0x7f;
   volume_control()->set_volume(s_volume);
+  volume_control()->set_enabled(true);
 
 #ifdef ESP_IDF_4
   volume_set_by_local_host(s_volume);
@@ -1189,14 +1189,13 @@ void BluetoothA2DPSink::app_rc_tg_callback(esp_avrc_tg_cb_event_t event, esp_avr
 void BluetoothA2DPSink::volume_set_by_controller(uint8_t volume)
 {
     ESP_LOGI(BT_AV_TAG, "Volume is set by remote controller to %d", (uint32_t)volume * 100 / 0x7f);
-    is_volume_used = true;
 
     _lock_acquire(&s_volume_lock);
     s_volume = volume;
     _lock_release(&s_volume_lock);
-    is_volume_used = true;
     
     volume_control()->set_volume(s_volume);
+    volume_control()->set_enabled(true);
 
     if (bt_volumechange!=nullptr){
         (*bt_volumechange)(s_volume);
@@ -1206,7 +1205,6 @@ void BluetoothA2DPSink::volume_set_by_controller(uint8_t volume)
 void BluetoothA2DPSink::volume_set_by_local_host(uint8_t volume)
 {
     ESP_LOGI(BT_AV_TAG, "Volume is set locally to: %d", (uint32_t)volume * 100 / 0x7f);
-    is_volume_used = true;
 
     _lock_acquire(&s_volume_lock);
     s_volume = volume;

--- a/src/BluetoothA2DPSink.h
+++ b/src/BluetoothA2DPSink.h
@@ -171,7 +171,9 @@ class BluetoothA2DPSink : public BluetoothA2DPCommon {
         set_mono_downmix(channels==I2S_CHANNEL_MONO);
     }
     /// mix stereo into single mono signal
-    virtual void set_mono_downmix(bool enabled) { mono_downmix = enabled; }
+    virtual void set_mono_downmix(bool enabled) {
+        volume_control()->set_mono_downmix(enabled);
+    }
     /// Defines the bits per sample for output (if > 16 output will be expanded)
     virtual void set_bits_per_sample(int bps) { i2s_config.bits_per_sample = (i2s_bits_per_sample_t) bps; }
     
@@ -231,7 +233,6 @@ class BluetoothA2DPSink : public BluetoothA2DPCommon {
     char pin_code_str[20] = {0};
     bool is_i2s_output = true;
     bool player_init = false;
-    bool mono_downmix = false;
     i2s_channel_t i2s_channels = I2S_CHANNEL_STEREO;
     i2s_port_t i2s_port = I2S_NUM_0; 
     int connection_rety_count = 0;
@@ -239,7 +240,6 @@ class BluetoothA2DPSink : public BluetoothA2DPCommon {
     static const esp_spp_mode_t esp_spp_mode = ESP_SPP_MODE_CB;
     _lock_t s_volume_lock;
     uint8_t s_volume = 0;
-    bool is_volume_used = false;
     bool s_volume_notify;
     int pin_code_int = 0;
     PinCodeRequest pin_code_request = Undefined;

--- a/src/BluetoothA2DPSource.cpp
+++ b/src/BluetoothA2DPSource.cpp
@@ -88,7 +88,7 @@ extern "C" int32_t ccall_bt_app_a2d_data_cb(uint8_t *data, int32_t len){
     int32_t result = (*(self_BluetoothA2DPSource->data_stream_callback))(data, len);
     // adapt volume
     if (result > 0 && self_BluetoothA2DPSource->is_volume_used){
-        self_BluetoothA2DPSource->volume_control()->update_audio_data((Frame*)data, result/4, false, true);
+        self_BluetoothA2DPSource->volume_control()->update_audio_data((Frame*)data, result/4);
     }
     return result;
 }

--- a/src/BluetoothA2DPSource.cpp
+++ b/src/BluetoothA2DPSource.cpp
@@ -88,7 +88,7 @@ extern "C" int32_t ccall_bt_app_a2d_data_cb(uint8_t *data, int32_t len){
     int32_t result = (*(self_BluetoothA2DPSource->data_stream_callback))(data, len);
     // adapt volume
     if (result > 0 && self_BluetoothA2DPSource->is_volume_used){
-        self_BluetoothA2DPSource->volume_control()->update_audio_data((Frame*)data, result/4, self_BluetoothA2DPSource->volume_value, false, true); 
+        self_BluetoothA2DPSource->volume_control()->update_audio_data((Frame*)data, result/4, false, true);
     }
     return result;
 }


### PR DESCRIPTION
The volume factor only changes when volume changes. It doesn't need to be re-computed on every data callback.
In addition the `pow` function in the is a relatively expensive to call which can be avoided.