### PR TITLE
Added support for a post I2S init callback.

### DIFF
--- a/src/BluetoothA2DPCommon.cpp
+++ b/src/BluetoothA2DPCommon.cpp
@@ -215,10 +215,19 @@ void BluetoothA2DPCommon::set_on_connection_state_changed(void (*callBack)(esp_a
 }
 
 /// Set the callback that is called when the audio state is changed
+/// This callback is called before the I2S bus is changed.
 void BluetoothA2DPCommon::set_on_audio_state_changed(void (*callBack)(esp_a2d_audio_state_t state, void*), void* obj){
     audio_state_callback = callBack;
     audio_state_obj = obj;
 }
+
+/// Set the callback that is called after the audio state has changed.
+/// This callback is called after the I2S bus has changed.
+void BluetoothA2DPCommon::set_on_audio_state_changed_post(void (*callBack)(esp_a2d_audio_state_t state, void*), void* obj){
+    audio_state_callback_post = callBack;
+    audio_state_obj_post = obj;
+}
+
 
 /// Prevents that the same method is executed multiple times within the indicated time limit
 void BluetoothA2DPCommon::debounce(void(*cb)(void),int ms){

--- a/src/BluetoothA2DPCommon.h
+++ b/src/BluetoothA2DPCommon.h
@@ -140,7 +140,12 @@ class BluetoothA2DPCommon {
         virtual esp_a2d_connection_state_t get_connection_state();
 
         /// Set the callback that is called when the connection state is changed
+        /// This callback is called before the I2S bus is changed.
         virtual void set_on_connection_state_changed(void (*callBack)(esp_a2d_connection_state_t state, void *), void *obj=nullptr);
+
+        /// Set the callback that is called after the audio state has changed.
+        /// This callback is called after the I2S bus has changed.
+        virtual void set_on_audio_state_changed_post(void (*callBack)(esp_a2d_audio_state_t state, void*), void* obj=nullptr);
 
         /// Set the callback that is called when the audio state is changed
         virtual void set_on_audio_state_changed(void (*callBack)(esp_a2d_audio_state_t state, void*), void* obj=nullptr);
@@ -194,8 +199,10 @@ class BluetoothA2DPCommon {
         bool is_start_disabled = false;
         void (*connection_state_callback)(esp_a2d_connection_state_t state, void* obj) = nullptr;
         void (*audio_state_callback)(esp_a2d_audio_state_t state, void* obj) = nullptr;
+        void (*audio_state_callback_post)(esp_a2d_audio_state_t state, void* obj) = nullptr;
         void *connection_state_obj = nullptr;
         void *audio_state_obj = nullptr;
+        void *audio_state_obj_post = nullptr;
         const char *m_a2d_conn_state_str[4] = {"Disconnected", "Connecting", "Connected", "Disconnecting"};
         const char *m_a2d_audio_state_str[3] = {"Suspended", "Stopped", "Started"};
         esp_a2d_audio_state_t audio_state = ESP_A2D_AUDIO_STATE_STOPPED;

--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -671,6 +671,10 @@ void BluetoothA2DPSink::handle_audio_state(uint16_t event, void *p_param){
             i2s_stop(i2s_port);
             i2s_zero_dma_buffer(i2s_port);
         }
+
+        if (audio_state_callback_post!=nullptr){
+            audio_state_callback_post(a2d->audio_stat.state, audio_state_obj_post);
+        }    
     }
 }
 


### PR DESCRIPTION
Hello,

I'm working with TI's [(TAS5805M)](https://www.ti.com/lit/ds/symlink/tas5805m.pdf?ts=1659808432711) amplifier. From reading section 7.5.3.1 I have to bring the PDN pin high and then wait 5ms before enabling I2S. After the I2S is enabled I can send I2C commands to finish the startup process.

To do this I have modified the code to create a second audio_state_callback function that is called after I2S is enabled.