### PR TITLE
add raw_stream_reader

### DIFF
--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -110,6 +110,10 @@ void BluetoothA2DPSink::set_stream_reader(void (*callBack)(const uint8_t*, uint3
   this->is_i2s_output = is_i2s;
 }
 
+void BluetoothA2DPSink::set_raw_stream_reader(void (*callBack)(const uint8_t*, uint32_t)){
+    this->raw_stream_reader = callBack;
+}
+
 void BluetoothA2DPSink::set_on_data_received(void (*callBack)()){
   this->data_received = callBack;
 }
@@ -1030,6 +1034,12 @@ void BluetoothA2DPSink::app_a2d_callback(esp_a2d_cb_event_t event, esp_a2d_cb_pa
 
 void BluetoothA2DPSink::audio_data_callback(const uint8_t *data, uint32_t len) {
     ESP_LOGD(BT_AV_TAG, "%s", __func__);
+
+    // make data available via callback, before volume control
+    if (raw_stream_reader!=nullptr){
+        ESP_LOGD(BT_AV_TAG, "raw_stream_reader");
+        (*raw_stream_reader)(data, len);
+    }
 
     // adjust the volume
     volume_control()->update_audio_data((Frame*)data, len/4);

--- a/src/BluetoothA2DPSink.h
+++ b/src/BluetoothA2DPSink.h
@@ -131,6 +131,9 @@ class BluetoothA2DPSink : public BluetoothA2DPCommon {
     /// Define callback which is called when we receive data: This callback provides access to the data
     virtual void set_stream_reader(void (*callBack)(const uint8_t*, uint32_t), bool i2s_output=true);
 
+    /// Define a callback that is called before the volume changes: this callback provides access to the data
+    virtual void set_raw_stream_reader(void (*callBack)(const uint8_t*, uint32_t));
+
     /// Define callback which is called when we receive data
     virtual void set_on_data_received(void (*callBack)());
     
@@ -289,6 +292,7 @@ class BluetoothA2DPSink : public BluetoothA2DPCommon {
     void (*bt_connected)() = nullptr;
     void (*data_received)() = nullptr;
     void (*stream_reader)(const uint8_t*, uint32_t) = nullptr;
+    void (*raw_stream_reader)(const uint8_t*, uint32_t) = nullptr;
     void (*avrc_metadata_callback)(uint8_t, const uint8_t*) = nullptr;
     bool (*address_validator)(esp_bd_addr_t remote_bda) = nullptr;
     void (*sample_rate_callback)(uint16_t rate)=nullptr;


### PR DESCRIPTION
I had a need to get sound data before changing the volume level, but without changing the library code, I could not do this. Therefore, I suggest also adding a `raw_stream_reader` for such cases.

PS: I am developing a color music device in which I convert the received audio samples to amplitudes using the fast fourier transform. You may ask, what is the need for processing samples that do not change in volume? I will answer, this is necessary for light modes with quiet parts in the audio composition, because depending on the volume, the algorithm can confuse a quiet place in the music with a low device volume.

I think the added functionality will also be useful when adding an equalizer, with direct and inverse Fourier transform, since the calculation at higher volume levels will occur with less distortion, which will have a better effect on quality. But I'm not sure about this.