### PR TITLE
Add play_pos callback with examples and README, also playing_time clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ In the ```a2dp_sink.set_stream_reader()``` method you can provide an optional pa
 
 ### Support for Metadata
 
-You can register a method which will be called when the system receives any AVRC metadata. Here is an example
+You can register a method which will be called when the system receives any AVRC metadata (`esp_avrc_md_attr_mask_t`). Here is an example
 ```
 void avrc_metadata_callback(uint8_t data1, const uint8_t *data2) {
   Serial.printf("AVRC metadata rsp: attribute id 0x%x, %s\n", data1, data2);
@@ -175,7 +175,11 @@ By default you should get the most important information, however you can adjust
 ```
 set_avrc_metadata_attribute_mask(ESP_AVRC_MD_ATTR_TITLE | ESP_AVRC_MD_ATTR_PLAYING_TIME);
 ```
-before you start the A2DP sink.
+before you start the A2DP sink. Note that data2 is actually a char* string, so even though `ESP_AVRC_MD_ATTR_PLAYING_TIME` is documented as the milliseconds of media duration you'll need to parse it before doing math on it. See the metadata example for more.
+
+### Support for Notifications
+
+Similarly to the `avrc_metadata_callback`, ESP IDF v4+ supports selected `esp_avrc_rn_param_t` callbacks like `set_avrc_rn_playstatus_callback` and `set_avrc_rn_play_pos_callback` which can be used to obtain `esp_avrc_playback_stat_t playback` playback status and `uint32_t play_pos` playback position respectively. See the playing_status_callbacks example for more.
 
 ### Support for AVRC Commands
 

--- a/examples/bt_music_receiver_playing_status_callbacks/bt_music_receiver_playing_status_callbacks.ino
+++ b/examples/bt_music_receiver_playing_status_callbacks/bt_music_receiver_playing_status_callbacks.ino
@@ -1,0 +1,61 @@
+/*
+  Streaming Music from Bluetooth
+
+  Copyright (C) 2020 Phil Schatzmann
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "AudioTools.h"
+#include "BluetoothA2DPSink.h"
+
+I2SStream out;
+BluetoothA2DPSink a2dp_sink(i2s);
+
+void avrc_rn_play_pos_callback(uint32_t play_pos) {
+  Serial.printf("Play position is %d (%d seconds)\n", play_pos, (int)round(play_pos/1000.0));
+}
+
+void avrc_rn_playstatus_callback(esp_avrc_playback_stat_t playback) {
+  switch (playback) {
+    case esp_avrc_playback_stat_t::ESP_AVRC_PLAYBACK_STOPPED:
+      Serial.println("Stopped.");
+      break;
+    case esp_avrc_playback_stat_t::ESP_AVRC_PLAYBACK_PLAYING:
+      Serial.println("Playing.");
+      break;
+    case esp_avrc_playback_stat_t::ESP_AVRC_PLAYBACK_PAUSED:
+      Serial.println("Paused.");
+      break;
+    case esp_avrc_playback_stat_t::ESP_AVRC_PLAYBACK_FWD_SEEK:
+      Serial.println("Forward seek.");
+      break;
+    case esp_avrc_playback_stat_t::ESP_AVRC_PLAYBACK_REV_SEEK:
+      Serial.println("Reverse seek.");
+      break;
+    case esp_avrc_playback_stat_t::ESP_AVRC_PLAYBACK_ERROR:
+      Serial.println("Error.");
+      break;
+    default:
+      Serial.printf("Got unknown playback status %d\n", playback);
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+  a2dp_sink.set_avrc_rn_playstatus_callback(avrc_rn_playstatus_callback);
+  a2dp_sink.set_avrc_rn_play_pos_callback(avrc_rn_play_pos_callback);
+  a2dp_sink.start("MyMusic");
+}
+
+void loop() {
+  Serial.println("Play or pause music to test callbacks.");
+  delay(10000);
+}

--- a/examples/bt_music_receiver_with_metadata/bt_music_receiver_with_metadata.ino
+++ b/examples/bt_music_receiver_with_metadata/bt_music_receiver_with_metadata.ino
@@ -22,10 +22,15 @@ bool is_active = true;
 
 void avrc_metadata_callback(uint8_t id, const uint8_t *text) {
   Serial.printf("==> AVRC metadata rsp: attribute id 0x%x, %s\n", id, text);
+  if (id == 0x40) {
+    uint32_t playtime = String((char*)text).toInt();
+    Serial.printf("==> Playing time is %d ms (%d seconds)\n", playtime, (int)round(playtime/1000.0));
+  }
 }
 
 void setup() {
   Serial.begin(115200);
+  a2dp_sink.set_avrc_metadata_attribute_mask(ESP_AVRC_MD_ATTR_TITLE | ESP_AVRC_MD_ATTR_ARTIST | ESP_AVRC_MD_ATTR_ALBUM | ESP_AVRC_MD_ATTR_PLAYING_TIME );
   a2dp_sink.set_avrc_metadata_callback(avrc_metadata_callback);
   a2dp_sink.start("MyMusic");
 }

--- a/src/BluetoothA2DPSink.cpp
+++ b/src/BluetoothA2DPSink.cpp
@@ -801,6 +801,12 @@ void BluetoothA2DPSink::av_notify_evt_handler(uint8_t event_id,
       ESP_LOGI(BT_AV_TAG, "Play position changed: %d-ms",
                event_parameter->play_pos);
       av_play_pos_changed();
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+      // call avrc play status notification callback if available
+      if (avrc_rn_play_pos_callback != nullptr) {
+        avrc_rn_play_pos_callback(event_parameter->play_pos);
+      }
+#endif
       break;
 
     default:

--- a/src/BluetoothA2DPSink.h
+++ b/src/BluetoothA2DPSink.h
@@ -211,10 +211,15 @@ class BluetoothA2DPSink : public BluetoothA2DPCommon {
   }
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
-  /// Define a callback method which provides the avrc notifications
+  /// Define a callback method which provides esp_avrc_playback_stat_t playback status notifications
   virtual void set_avrc_rn_playstatus_callback(
       void (*callback)(esp_avrc_playback_stat_t playback)) {
     this->avrc_rn_playstatus_callback = callback;
+  }
+  /// Define a callback method which provides esp_avrc_rn_param_t play position notifications
+  virtual void set_avrc_rn_play_pos_callback(
+      void (*callback)(uint32_t play_pos)) {
+    this->avrc_rn_play_pos_callback = callback;
   }
 #endif
 
@@ -404,6 +409,7 @@ class BluetoothA2DPSink : public BluetoothA2DPCommon {
   void (*avrc_metadata_callback)(uint8_t, const uint8_t *) = nullptr;
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
   void (*avrc_rn_playstatus_callback)(esp_avrc_playback_stat_t) = nullptr;
+  void (*avrc_rn_play_pos_callback)(uint32_t) = nullptr;
 #endif
   void (*avrc_rn_volchg_complete_callback)(int) = nullptr;
   bool (*address_validator)(esp_bd_addr_t remote_bda) = nullptr;


### PR DESCRIPTION
After lots of digging around, I realized that rather than mess with ESP_AVRC_RN_PLAY_POS_CHANGED and esp_avrc_ct_send_register_notification_cmd and esp_avrc_rn_param_t.play_pos, we have an example implementation of a callback all ready to go with `avrc_rn_playstatus_callback(event_parameter->playback)` just a few lines above, and indeed a `av_play_pos_changed()` function ready to go, so all that's left is to make a `avrc_rn_play_pos_callback()` and we can easily display song progress with the same API we're already used to.

In implementing a song progress indicator I also ran into the confusing situation that ESP_AVRC_MD_ATTR_PLAYING_TIME is not just milliseconds of total song time but *milliseconds stored as text in a `char*`* which seemed to cause plenty of confusion as well, so I added some language to the README and example to help people with that little headache.

Modifications/improvements/etc welcome, thanks for providing this great library!

Fixes #102 #236 #400 #491 #506 #526