### PR TITLE
Added in Bluetooth Discovery Mode callback

### DIFF
--- a/src/BluetoothA2DPSource.cpp
+++ b/src/BluetoothA2DPSource.cpp
@@ -970,10 +970,17 @@ void BluetoothA2DPSource::bt_av_hdl_avrc_ct_evt(uint16_t event, void *p_param) {
   }
   /* when passthrough responsed, this event comes */
   case ESP_AVRC_CT_PASSTHROUGH_RSP_EVT: {
-    ESP_LOGI(
+    #if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 1, 0)
+      ESP_LOGI(
+        BT_RC_CT_TAG,
+        "AVRC passthrough response: key_code 0x%x, key_state %d",
+        rc->psth_rsp.key_code, rc->psth_rsp.key_state);
+    #else
+      ESP_LOGI(
         BT_RC_CT_TAG,
         "AVRC passthrough response: key_code 0x%x, key_state %d, rsp_code %d",
         rc->psth_rsp.key_code, rc->psth_rsp.key_state, rc->psth_rsp.rsp_code);
+    #endif
     break;
   }
   /* when metadata responsed, this event comes */

--- a/src/BluetoothA2DPSource.cpp
+++ b/src/BluetoothA2DPSource.cpp
@@ -461,6 +461,7 @@ void BluetoothA2DPSource::bt_app_gap_callback(esp_bt_gap_cb_event_t event,
   }
   case ESP_BT_GAP_DISC_STATE_CHANGED_EVT: {
     if (param->disc_st_chg.state == ESP_BT_GAP_DISCOVERY_STOPPED) {
+      if(discovery_mode_callback)discovery_mode_callback(ESP_BT_GAP_DISCOVERY_STOPPED);
       if (s_a2d_state == APP_AV_STATE_DISCOVERED) {
         s_a2d_state = APP_AV_STATE_CONNECTING;
         ESP_LOGI(BT_AV_TAG, "Device discovery stopped.");
@@ -472,6 +473,7 @@ void BluetoothA2DPSource::bt_app_gap_callback(esp_bt_gap_cb_event_t event,
         esp_bt_gap_start_discovery(ESP_BT_INQ_MODE_GENERAL_INQUIRY, 10, 0);
       }
     } else if (param->disc_st_chg.state == ESP_BT_GAP_DISCOVERY_STARTED) {
+      if(discovery_mode_callback)discovery_mode_callback(ESP_BT_GAP_DISCOVERY_STARTED);
       ESP_LOGI(BT_AV_TAG, "Discovery started.");
     }
     break;

--- a/src/BluetoothA2DPSource.h
+++ b/src/BluetoothA2DPSource.h
@@ -185,6 +185,11 @@ class BluetoothA2DPSource : public BluetoothA2DPCommon {
       ssid_callback = callback;
     }
 
+    /// Define callback to be notified about bt discovery mode state changes
+    void set_bt_discovery_mode_callback(void(*callback)(esp_bt_gap_discovery_state_t discoveryMode)){
+      discovery_mode_callback = callback;
+    }
+
   protected:
     music_data_channels_cb_t data_stream_channels_callback;
     const char *dev_name = "ESP32_A2DP_SRC";
@@ -218,6 +223,7 @@ class BluetoothA2DPSource : public BluetoothA2DPCommon {
     music_data_cb_t data_stream_callback;
 
     bool(*ssid_callback)(const char*ssid, esp_bd_addr_t address, int rrsi) = nullptr;
+    void(*discovery_mode_callback)(esp_bt_gap_discovery_state_t discoveryMode) = nullptr;
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
     esp_avrc_rn_evt_cap_mask_t s_avrc_peer_rn_cap;


### PR DESCRIPTION
Added in a callback that is similar to the SSID_callback. The new callback allows you to be notified when the Discovery Mode changes.