### PR TITLE
added in conditional logic based on ESP_IDF version for rsp_code support

### DIFF
--- a/src/BluetoothA2DPSource.cpp
+++ b/src/BluetoothA2DPSource.cpp
@@ -968,10 +968,17 @@ void BluetoothA2DPSource::bt_av_hdl_avrc_ct_evt(uint16_t event, void *p_param) {
   }
   /* when passthrough responsed, this event comes */
   case ESP_AVRC_CT_PASSTHROUGH_RSP_EVT: {
-    ESP_LOGI(
+    #if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 1, 0)
+      ESP_LOGI(
+        BT_RC_CT_TAG,
+        "AVRC passthrough response: key_code 0x%x, key_state %d",
+        rc->psth_rsp.key_code, rc->psth_rsp.key_state);
+    #else
+      ESP_LOGI(
         BT_RC_CT_TAG,
         "AVRC passthrough response: key_code 0x%x, key_state %d, rsp_code %d",
         rc->psth_rsp.key_code, rc->psth_rsp.key_state, rc->psth_rsp.rsp_code);
+    #endif
     break;
   }
   /* when metadata responsed, this event comes */


### PR DESCRIPTION
Added in compile macros to change the code based on IDF version support of rsp_code.

rsp_code is not supported before idf version 5.1