### PR TITLE
completely removed major service filtering because there are bluetoot…

### DIFF
--- a/src/BluetoothA2DPSource.cpp
+++ b/src/BluetoothA2DPSource.cpp
@@ -406,13 +406,7 @@ void BluetoothA2DPSource::filter_inquiry_scan_result(
       break;
     }
   }
-  /* search for device with MAJOR service class as "rendering" in COD */
-  if (!esp_bt_gap_is_valid_cod(cod) ||
-      !(esp_bt_gap_get_cod_srvc(cod) & ESP_BT_COD_SRVC_RENDERING)) {
-    ESP_LOGI(BT_AV_TAG, "--Compatiblity: Incompatible");
-    return;
-  }
-
+  
   /* search for target device in its Extended Inqury Response */
   if (eir) {
 


### PR DESCRIPTION
completely removed major service filtering because there are bluetooth speakers that do this wrong. Without this filtering, the user will be presented with a list of ALL bluetooth devices. They will have to know which ones to select. The current bluetooth speaker I am connecting to COD 0x414. This is being filtered out by the current implementation. Secondly, there are other major services that should have been included in the filter. At a minimum, the filtering should be looking at:

ESP_BT_COD_SRVC_RENDERING
ESP_BT_COD_SRVC_AUDIO
ESP_BT_COD_SRVC_TELEPHONY

Since there is no guarantee to other Bluetooth devices will do this correctly, why filter out devices that could be compatible, but are just reporting out the COD incorrectly. I know you have had a lot of reports of speakers not showing up that should have...