### PR TITLE
Fix build on PlatformIO alongside AudioTools

### DIFF
--- a/src/BluetoothA2DPOutput.h
+++ b/src/BluetoothA2DPOutput.h
@@ -10,7 +10,8 @@
 #endif
 
 #if A2DP_I2S_AUDIOTOOLS
-#include "AudioTools.h"
+#include "AudioTools/CoreAudio/AudioStreams.h"
+#include "AudioTools/CoreAudio/AudioIO.h"
 #endif
 
 /**


### PR DESCRIPTION
On PlatformIO having both this library and Arduino-Audio-Tools in the same project results in a circular dependency in the BluetoothA2DPOutput file, which leads to the following build error:

```
In file included from .pio/libdeps/esp32dev/ArduinoAudioTools/src/AudioTools/CoreAudio/AudioHttp/AudioHttp.h:8,
                 from .pio/libdeps/esp32dev/ArduinoAudioTools/src/AudioTools.h:99,
                 from lib/ESP32-A2DP/src/BluetoothA2DPOutput.h:15,
                 from lib/ESP32-A2DP/src/BluetoothA2DPOutput.cpp:1:
.pio/libdeps/esp32dev/ArduinoAudioTools/src/AudioTools/CoreAudio/AudioHttp/URLStream.h:8:11: fatal error: WiFi.h: No such file or directory

 # include <WiFi.h>
           ^~~~~~~~
compilation terminated.
In file included from .pio/libdeps/esp32dev/ArduinoAudioTools/src/AudioTools/CoreAudio/AudioHttp/AudioHttp.h:8,
                 from .pio/libdeps/esp32dev/ArduinoAudioTools/src/AudioTools.h:99,
                 from lib/ESP32-A2DP/src/BluetoothA2DPOutput.h:15,
                 from lib/ESP32-A2DP/src/BluetoothA2DPSink.h:18,
                 from lib/ESP32-A2DP/src/BluetoothA2DPSink.cpp:16:
.pio/libdeps/esp32dev/ArduinoAudioTools/src/AudioTools/CoreAudio/AudioHttp/URLStream.h:8:11: fatal error: WiFi.h: No such file or directory

 # include <WiFi.h>
           ^~~~~~~~
compilation terminated.
In file included from .pio/libdeps/esp32dev/ArduinoAudioTools/src/AudioTools/CoreAudio/AudioHttp/AudioHttp.h:8,
                 from .pio/libdeps/esp32dev/ArduinoAudioTools/src/AudioTools.h:99,
                 from lib/ESP32-A2DP/src/BluetoothA2DPOutput.h:15,
                 from lib/ESP32-A2DP/src/BluetoothA2DPSink.h:18,
                 from lib/ESP32-A2DP/src/BluetoothA2DPSinkQueued.h:3,
                 from lib/ESP32-A2DP/src/BluetoothA2DPSinkQueued.cpp:2:
.pio/libdeps/esp32dev/ArduinoAudioTools/src/AudioTools/CoreAudio/AudioHttp/URLStream.h:8:11: fatal error: WiFi.h: No such file or directory


 # include <WiFi.h>
           ^~~~~~~~
compilation terminated.
*** [.pio\build\esp32dev\lib1d0\ESP32-A2DP\BluetoothA2DPOutput.cpp.o] Error 1
*** [.pio\build\esp32dev\lib1d0\ESP32-A2DP\BluetoothA2DPSink.cpp.o] Error 1
*** [.pio\build\esp32dev\lib1d0\ESP32-A2DP\BluetoothA2DPSinkQueued.cpp.o] Error 1
```

To avoid this error I changed the file to only import the necessary part of AudioTools and not the whole library, so it can build successfully now