### PR TITLE
fix: replace bare millis() calls with get_millis() in BluetoothA2DPSource

### DIFF
--- a/src/BluetoothA2DPSource.cpp
+++ b/src/BluetoothA2DPSource.cpp
@@ -81,7 +81,7 @@ BluetoothA2DPSource::~BluetoothA2DPSource() { end(); }
 
 bool BluetoothA2DPSource::is_active(unsigned long timeout) {
   if (last_heart_beat == 0) return false;
-  return millis() - last_heart_beat < timeout;
+  return get_millis() - last_heart_beat < timeout;
 }
 
 void BluetoothA2DPSource::set_pin_code(const char *pin_code,
@@ -640,7 +640,7 @@ void BluetoothA2DPSource::bt_app_av_sm_hdlr(uint16_t event, void *param) {
       break;
     case APP_AV_STATE_CONNECTED:
       bt_app_av_state_connected_hdlr(event, param);
-      last_heart_beat = millis();
+      last_heart_beat = get_millis();
       break;
     case APP_AV_STATE_DISCONNECTING:
       bt_app_av_state_disconnecting_hdlr(event, param);


### PR DESCRIPTION
## Description

`BluetoothA2DPSource.cpp` calls `millis()` directly in two places:

- `is_active()` (line 84)
- `bt_app_av_sm_hdlr()` (line 643)

`millis()` is Arduino-only and does not exist under bare ESP-IDF. The base class
`BluetoothA2DPCommon` already provides `get_millis()` which wraps this correctly:

```cpp
#ifdef ARDUINO
  return millis();
#else
  return (unsigned long)(esp_timer_get_time() / 1000ULL);
#endif
```

Both call sites are changed to use `get_millis()` instead.

## Impact

Users building with PlatformIO `framework = espidf` (no Arduino core) get a
compile error in `BluetoothA2DPSource.cpp` because `millis` is undeclared.
The fix makes `BluetoothA2DPSource` build under bare ESP-IDF, consistent with
the README statement that "There are no other dependencies and this includes
the Arduino API."

## Changes

- `src/BluetoothA2DPSource.cpp`: two `millis()` → `get_millis()`

## Testing

Verified compile under PlatformIO with `framework = espidf` (ESP-IDF 5.3.1).
No behaviour change for Arduino builds — `get_millis()` delegates to `millis()`
when `ARDUINO` is defined.